### PR TITLE
fix: ensure sail network is external in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ networks:
     sail:
         driver: bridge
         name: sail
+        external: true
         
 #Volumes
 volumes:


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change specifies that the `sail` network should be external.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R66): Added `external: true` to the `sail` network configuration.